### PR TITLE
Add ga campaign autotagging parameter

### DIFF
--- a/google_analytics/__init__.py
+++ b/google_analytics/__init__.py
@@ -4,4 +4,5 @@ CAMPAIGN_TRACKING_PARAMS = {
     'cs': 'utm_source',
     'cm': 'utm_medium',
     'cn': 'utm_campaign',
+    'gclid': 'gclid',
 }

--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -363,6 +363,24 @@ class GoogleAnalyticsTestCase(TestCase):
                 ga_dict_with_campaign_params.get(
                     'utm_url')).get('cm'), None)
 
+    @responses.activate
+    def test_build_ga_params_for_campaign_auto_tagging(self):
+        '''
+        Test that the GA campaign auto-tagging
+        tracking params are tracked correctly
+        '''
+        request = self.make_fake_request(
+            '/somewhere/?gclid=TeSter-123-ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefgh'
+            'ijklmnopqrstuvwxyz-0123456789-AaBbCcDdEeFfGgHhIiJjKkLl')
+        ga_dict_with_campaign_params = build_ga_params(
+            request, 'ua-test-id', '/compaign/path/')
+        self.assertEqual(
+            parse_qs(ga_dict_with_campaign_params.get(
+                'utm_url')).get('gclid'),
+            ['TeSter-123-ABCDEFGHIJKLMNOPQRSTUVWXYZ-abcdefghijklmnopqrstuvwxyz'
+             '-0123456789-AaBbCcDdEeFfGgHhIiJjKkLl']
+            )
+
     @override_settings(MIDDLEWARE=[
         'django.contrib.sessions.middleware.SessionMiddleware',
         'google_analytics.middleware.GoogleAnalyticsMiddleware'


### PR DESCRIPTION
GA now allows autotagging for campaigns. Instead of the usual campaign parameters, that need to be manually added to a url, they send through a single click id parameter.
This PR adds the new parameter to the ones that allowed for GA campaigns.