### PR TITLE
Clarify installation on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,11 @@ Installation
 ------------
 
 #. Install ``django-google-analytics-app`` from PyPI or add to your Python path some other way.
-#. Add ``google_analytics`` to you ``INSTALLED_APPS`` setting.
+#. Add ``google_analytics`` to your ``INSTALLED_APPS`` setting.
 #. Add URL include to your project's ``urls.py`` file::
 
-    (r'^djga/', include('google_analytics.urls')),
+    (r'^djga/', include('google_analytics.urls')),        # This line for Django versions <= 1.11
+    re_path('djga/', include('google_analytics.urls')),   # This line for Django versions >=2.0
 
 #. Specify a Google Analytics `tracking code <https://support.google.com/analytics/bin/answer.py?hl=en&answer=1008080>`_, i.e.::
 


### PR DESCRIPTION
Clarifies the setup process for people using Django versions >=2.0.

Django gives the following warning if using the old style regular expression URL pattern.

> WARNINGS:
web_1       | ?: (2_0.W001) Your URL pattern '^djga/' has a route that contains '(?P<', begins with a '^', or ends with a '$'. This was likely an oversight when migrating to django.urls.path().



Also, a minor typo fix.