### PR TITLE
Update codebase for Django 3 and Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ jobs:
       env: TOXENV=py36-dj20
     - python: '3.6'
       env: TOXENV=py36-dj21
+    - python: '3.6'
+      env: TOXENV=py36-dj30
     - python: '3.7'
       env: TOXENV=py37-dj111
     - python: '3.7'
@@ -30,6 +32,12 @@ jobs:
       env: TOXENV=py37-dj21
     - python: '3.7'
       env: TOXENV=py37-dj22
+    - python: '3.7'
+      env: TOXENV=py37-dj30
+    - python: '3.8'
+      env: TOXENV=py38-dj22
+    - python: '3.8'
+      env: TOXENV=py38-dj30
 
     - python: '3.6'
       env: TOXENV=lint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+4.4.1
+----------
+# Add Django 3.0 and Python 3.8 support
+
 4.4.0
 ----------
 # Add django 2.2+ support, drop support for python 2
@@ -26,7 +30,7 @@ Changelog
 
 4.3.5
 ----------
-#.Remove self referal traffic
+#.Remove self referral traffic
 
 4.3.4
 ----------
@@ -91,7 +95,7 @@ Changelog
 
 2.1.0
 -----
-#. Allow uip to be overriden using custom header
+#. Allow uip to be overridden using custom header
 
 2.0.3
 -----

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def read(*parts):
 
 setup(
     name='django-google-analytics-app',
-    version='4.4.0',
+    version='4.4.1',
     description=('Django Google Analytics app allowing for server side/non-js '
                  'tracking.'),
     long_description=read('README.rst'),
@@ -23,7 +23,7 @@ setup(
     url='http://github.com/praekelt/django-google-analytics',
     packages=find_packages(),
     install_requires=[
-        'Django>=2.2.5,<2.3',
+        'Django>=2.2.5,<3.1',
         'django-celery',
         'celery<4.0',
         'requests',
@@ -48,7 +48,9 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
+    keywords=['django', 'google', 'analytics'],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,8 @@
 envlist =
   py{35,36,37}-dj{111}
   py{35,36,37}-dj{20,21}
+  py{35,36,37,38}-dj{22}
+  py{36,37,38}-dj{30,31}
   lint
 
 [testenv]
@@ -10,6 +12,7 @@ deps =
   dj20: Django>=2.0,<2.1
   dj21: Django>=2.1,<2.2
   dj22: Django>=2.2,<2.3
+  dj30: Django>=3.0,<3.1
   coverage
 extras = test
 setenv =


### PR DESCRIPTION
Added configurations to `travis.yml`, `setup.py` and `tox.ini` to account for the various compatibility versions between Django and Python (as listed [here on the Django website](https://docs.djangoproject.com/en/dev/faq/install/#what-python-version-can-i-use-with-django))

- Also added keywords to `setup.py` to aid discoverability
- Updated `CHANGELOG.rst` to add compatibility for Django 3 and Python 3.8. Also corrected a couple of typos
- I noticed that the development status is listed as `4 - Beta` in `setup.py`. Is there any reason why this is still in Beta? I'll let you change it if you think it is ready to be changed to `5 - Production/Stable`

Since the default branch is `develop`, I have made the PR against it.

Please feel free to make any changes as you see fit and squash the commits if you think is neater.

Once all of the tests have passed, will you be updating `master` and releasing a new version to PyPI to account for the changes?