### PR TITLE
Add support for Django 3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# VS Code
+.vscode/*
+
 # pyenv
 .python-version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ jobs:
       env: TOXENV=py36-dj21
     - python: '3.6'
       env: TOXENV=py36-dj30
+    - python: '3.6'
+      env: TOXENV=py36-dj31
     - python: '3.7'
       env: TOXENV=py37-dj111
     - python: '3.7'
@@ -34,10 +36,14 @@ jobs:
       env: TOXENV=py37-dj22
     - python: '3.7'
       env: TOXENV=py37-dj30
+    - python: '3.7'
+      env: TOXENV=py37-dj31
     - python: '3.8'
       env: TOXENV=py38-dj22
     - python: '3.8'
       env: TOXENV=py38-dj30
+    - python: '3.8'
+      env: TOXENV=py38-dj31
 
     - python: '3.6'
       env: TOXENV=lint

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+4.4.2
+----------
+# Add support for Django 3.1
+# Add support for Celery 4.x.x
+
+----------
 4.4.1
 ----------
 # Add Django 3.0 and Python 3.8 support

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,9 +3,7 @@ Changelog
 4.4.2
 ----------
 # Add support for Django 3.1
-# Add support for Celery 4.x.x
 
-----------
 4.4.1
 ----------
 # Add Django 3.0 and Python 3.8 support

--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,10 @@ Installation
 #. Specify a Google Analytics `tracking code <https://support.google.com/analytics/bin/answer.py?hl=en&answer=1008080>`_, i.e.::
 
     GOOGLE_ANALYTICS = {
-        'google_analytics_id': 'xxx',
+        'google_analytics_id': 'UA-000000-2',
     }
 
-   where ``xxx`` is your tracking code.
+   where ``UA-000000-2`` is your unique tracking code.
 
 #. If you intend tracking through middleware and Celery remember to `install Celery and run its worker process <http://docs.celeryproject.org/en/latest/django/first-steps-with-django.html>`_.
 

--- a/google_analytics/middleware.py
+++ b/google_analytics/middleware.py
@@ -1,8 +1,9 @@
 from bs4 import BeautifulSoup
+
 from django.conf import settings
 from django.utils.deprecation import MiddlewareMixin
-from google_analytics.utils import build_ga_params, set_cookie
 from google_analytics.tasks import send_ga_tracking
+from google_analytics.utils import build_ga_params, set_cookie
 
 
 class GoogleAnalyticsMiddleware(MiddlewareMixin):

--- a/google_analytics/tasks.py
+++ b/google_analytics/tasks.py
@@ -1,4 +1,5 @@
 import requests
+
 from celery.task import task
 
 

--- a/google_analytics/templatetags/google_analytics_tags.py
+++ b/google_analytics/templatetags/google_analytics_tags.py
@@ -1,9 +1,9 @@
+from six.moves.urllib.parse import parse_qs, urlencode, urlparse
+
 from django import template
 from django.conf import settings
 from django.urls import reverse
 from google_analytics import CAMPAIGN_TRACKING_PARAMS
-
-from six.moves.urllib.parse import parse_qs, urlencode, urlparse
 
 register = template.Library()
 
@@ -47,6 +47,6 @@ def google_analytics(context, tracking_code=None, debug=False):
         params['utmdebug'] = 1
     # build and return the url
     url = reverse('google-analytics')
-    if len(params) > 0:
+    if params:
         url += '?&' + urlencode(params)
     return url

--- a/google_analytics/tests/test_ga.py
+++ b/google_analytics/tests/test_ga.py
@@ -2,20 +2,18 @@
 
 import unittest
 
-import responses
+from six.moves.urllib.parse import parse_qs
 
 import django
+import responses
+from django.contrib.sessions.middleware import SessionMiddleware
 from django.http import HttpResponse
 from django.test import TestCase, override_settings
-from django.test.client import Client
-from django.test.client import RequestFactory
-from django.contrib.sessions.middleware import SessionMiddleware
-
-from google_analytics.utils import COOKIE_NAME, build_ga_params
-from google_analytics.templatetags.google_analytics_tags import google_analytics # noqa
+from django.test.client import Client, RequestFactory
 from google_analytics.middleware import GoogleAnalyticsMiddleware
-
-from six.moves.urllib.parse import parse_qs
+from google_analytics.templatetags.google_analytics_tags import \
+    google_analytics  # noqa
+from google_analytics.utils import COOKIE_NAME, build_ga_params
 
 
 class GoogleAnalyticsTestCase(TestCase):

--- a/google_analytics/tests/test_templatetags_google_analytics_tags.py
+++ b/google_analytics/tests/test_templatetags_google_analytics_tags.py
@@ -1,9 +1,7 @@
-from google_analytics.templatetags.google_analytics_tags import (
-    google_analytics,
-)
-
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase, override_settings
+from google_analytics.templatetags.google_analytics_tags import \
+    google_analytics
 
 
 class GoogleAnalyticsTagsTestCase(TestCase):

--- a/google_analytics/urls.py
+++ b/google_analytics/urls.py
@@ -1,7 +1,6 @@
 from django.conf.urls import url
 from google_analytics.views import google_analytics
 
-
 urlpatterns = [
     url(r'^google-analytics/$', google_analytics, name='google-analytics'),
 ]

--- a/google_analytics/utils.py
+++ b/google_analytics/utils.py
@@ -1,15 +1,15 @@
 import random
 import time
 import uuid
-import structlog
-
-from django.conf import settings
-from django.utils.translation import get_language_from_request
-
-from google_analytics import CAMPAIGN_TRACKING_PARAMS
 
 from six import text_type
 from six.moves.urllib.parse import quote, urlencode
+
+import structlog
+from django.conf import settings
+from django.utils.translation import get_language_from_request
+from google_analytics import CAMPAIGN_TRACKING_PARAMS
+
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -61,11 +61,7 @@ def build_ga_params(
     meta = request.META
     # determine the domian
     domain = meta.get('HTTP_HOST', '')
-    if request.method == 'GET':
-        ni = '0'
-    else:
-        ni = '1'
-
+    ni = '0' if request.method == 'GET' else '1'
     # determine the referrer
     referer = referer or request.GET.get('r', '')
     parse_referer = urlparse(referer)
@@ -148,11 +144,10 @@ def build_ga_params(
     ga_url = "http://www.google-analytics.com/collect"
     utm_url = ga_url + "?&" + urlencode(params)
     ga_logging_enabled = False
-    if hasattr(settings, 'ENABLE_GA_LOGGING'):
-        if settings.ENABLE_GA_LOGGING:
-            log = structlog.get_logger()
-            log.msg('GA_URL: %s' % utm_url, user_agent=user_agent)
-            ga_logging_enabled = True
+    if hasattr(settings, 'ENABLE_GA_LOGGING') and settings.ENABLE_GA_LOGGING:
+        log = structlog.get_logger()
+        log.msg('GA_URL: %s' % utm_url, user_agent=user_agent)
+        ga_logging_enabled = True
 
     locale = get_language_from_request(request)
 

--- a/google_analytics/views.py
+++ b/google_analytics/views.py
@@ -3,10 +3,10 @@ import struct
 from functools import reduce
 
 import requests
+
 from django.http import HttpResponse
 from django.views.decorators.cache import never_cache
 from google_analytics.utils import build_ga_params, set_cookie
-
 
 GIF_DATA = reduce(lambda x, y: x + struct.pack('B', y),
                   [0x47, 0x49, 0x46, 0x38, 0x39, 0x61,

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     url='http://github.com/praekelt/django-google-analytics',
     packages=find_packages(),
     install_requires=[
-        'Django>=2.2.5,<3.1',
+        'Django>=2.2.5,<3.2',
         'django-celery',
         'celery<5.0',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import codecs
 import os
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'Django>=2.2.5,<3.1',
         'django-celery',
-        'celery<4.0',
+        'celery<5.0',
         'requests',
         'beautifulsoup4',
         'six',
@@ -37,7 +37,7 @@ setup(
     },
     include_package_data=True,
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires=[
         'Django>=2.2.5,<3.2',
         'django-celery',
-        'celery<5.0',
+        'celery<4.0',
         'requests',
         'beautifulsoup4',
         'six',

--- a/test_settings.py
+++ b/test_settings.py
@@ -1,6 +1,5 @@
 import os
 
-
 SECRET_KEY = 'foo'
 BASE_DIR = os.path.dirname(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
   dj21: Django>=2.1,<2.2
   dj22: Django>=2.2,<2.3
   dj30: Django>=3.0,<3.1
+  dj31: Django>=3.1,<3.2
   coverage
 extras = test
 setenv =


### PR DESCRIPTION
When trying to install a celery version greater than 4 to a project,
PipEnv cannot resolve the dependency since `setup.py` is set to <4.0

It is also clear that the package does not currently support Django 3.1

This commit addresses the following issues:

- Updates the Tox/Travis config to allow for the testing of Django 3.1
  with its supported Python versions (3.6, 3.7, and 3.8)
  See: https://docs.djangoproject.com/en/3.1/faq/install/
- Updates `setup.py` to have a constraint for celery of <5.0
- A couple of refactoring changes:
    - Replace nested if condition with a ternary operator (conditional
      expression)
    - Test params for truthiness instead of its length
- Ran `isort` over the project and accepted its sorted imports
- Updates `README.rst` to have an example Google Analytics code that is
  aligned with the Google docs and a user's actual tracking code.
- Added `.vscode` to the `.gitignore` file to help VS Code contributors
- Updated `CHANGELOG.rst` with the more major points of the change
- Altered `Development Status` classifier to `5 - Production/Stable`.
  This was agreed in PR #62 by @rudigiesler

I have NOT changed the version number within `setup.py`. I will let you
do this upon build/release.