### PR TITLE
Update celery

### DIFF
--- a/google_analytics/tasks.py
+++ b/google_analytics/tasks.py
@@ -1,9 +1,9 @@
 import requests
 
-from celery import task
+from celery import shared_task
 
 
-@task(ignore_result=True)
+@shared_task(ignore_result=True)
 def send_ga_tracking(params):
     utm_url = params.get('utm_url')
     user_agent = params.get('user_agent')

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         'Django>=2.2.5,<4.1',
-        'celery<5.0.0',
+        'celery<6.0.0',
         'requests',
         'beautifulsoup4',
         'six',


### PR DESCRIPTION
There is a CVE in celery < 5.2.2, so we need to upgrade to celery 5 to get the fix.

This PR opens up the celery dependancy to celery 5, and makes the changes necessary to support celery 5
